### PR TITLE
Fix path for `optional-features.json`

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = {
     let features = {};
 
     try {
-      Object.assign(features, this.project.require('config/optional-features.json'));
+      Object.assign(features, this.project.require('./config/optional-features.json'));
     } catch(err) {
       if (err.code !== 'MODULE_NOT_FOUND') {
         throw err;

--- a/tests/optional-features-test.js
+++ b/tests/optional-features-test.js
@@ -10,7 +10,7 @@ class Project {
   require(path) {
     let features = this.features;
 
-    if (path === 'config/optional-features.json' && typeof features === 'object') {
+    if (path === './config/optional-features.json' && typeof features === 'object') {
       return this.features;
     } else {
       let error = new Error(`Invalid path: ${path}`);


### PR DESCRIPTION
This is a small change that fixes #11. I've confirmed that the change causes the application template wrapper feature to work as expected on two different apps.

application.hbs
```
Testing
```

![image](https://user-images.githubusercontent.com/2442245/36795806-f3c67436-1c71-11e8-80b3-0351aaf50eb8.png)
