### PR TITLE
Rename `isEnabled` to `featureIsEnabled`

### DIFF
--- a/commands/index.js
+++ b/commands/index.js
@@ -24,7 +24,7 @@ const SHARED = {
   // TODO: promisify the sync code below
 
   _isFeatureAvailable(feature) {
-    let checker = new VersionChecker(this).forEmber();
+    let checker = new VersionChecker(this.project).forEmber();
     return checker.gte(`${feature.since}-beta.1`);
   },
 
@@ -51,7 +51,7 @@ const SHARED = {
 
     if (feature === undefined) {
       console.log(chalk.red(`Error: ${chalk.bold(name)} is not a valid feature.\n`));
-      return LIST_FEATURES.run();
+      return LIST_FEATURES.run.apply(this);
     }
 
     let configPath = yield this._ensureConfigFile();

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ module.exports = {
     return validated;
   },
 
-  isEnabled(name) {
+  isFeatureEnabled(name) {
     return this._features[name];
   },
 

--- a/tests/optional-features-test.js
+++ b/tests/optional-features-test.js
@@ -102,13 +102,13 @@ QUnit.module('@ember/optional-features', hooks => {
     assert.deepEqual(addon.config(), expected, 'Expecting correct config');
   });
 
-  QUnit.test('it can query the features with `isEnabled`', assert => {
+  QUnit.test('it can query the features with `isFeatureEnabled`', assert => {
     let addon = buildAddon({
       'application-template-wrapper': false
     });
 
-    assert.strictEqual(addon.isEnabled('application-template-wrapper'), false, 'Expecting suppied value');
-    assert.strictEqual(addon.isEnabled('template-only-glimmer-components'), false, 'Expecting default value');
+    assert.strictEqual(addon.isFeatureEnabled('application-template-wrapper'), false, 'Expecting suppied value');
+    assert.strictEqual(addon.isFeatureEnabled('template-only-glimmer-components'), false, 'Expecting default value');
   });
 
   QUnit.test('it allows the config to be a overridden with an ENV variable', assert => {
@@ -119,7 +119,7 @@ QUnit.module('@ember/optional-features', hooks => {
       'template-only-glimmer-components': true
     });
 
-    assert.strictEqual(addon.isEnabled('application-template-wrapper'), false, 'Expecting value from ENV var');
-    assert.strictEqual(addon.isEnabled('template-only-glimmer-components'), true, 'Expecting value from JSON');
+    assert.strictEqual(addon.isFeatureEnabled('application-template-wrapper'), false, 'Expecting value from ENV var');
+    assert.strictEqual(addon.isFeatureEnabled('template-only-glimmer-components'), true, 'Expecting value from JSON');
   });
 });


### PR DESCRIPTION
It happens that `addon#isEnabled` has a meaning already for ember-cli: https://github.com/ember-cli/ember-cli/blob/f14a2770131dc2427f086b6f2771031dc517797c/lib/broccoli/ember-app.js#L505-L507. 

Debugging the addon I discovered that it was being called several times with no arguments.