### PR TITLE
Do not populate EmberENV with default values

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,6 @@ module.exports = {
     this._features = this._validateFeatures(this._loadFeatures());
   },
 
-
   _loadFeatures() {
     let features = {};
 
@@ -52,8 +51,6 @@ module.exports = {
     Object.keys(FEATURES).forEach(key => {
       if (typeof features[key] === 'boolean') {
         validated[key] = features[key];
-      } else {
-        validated[key] = FEATURES[key].default;
       }
     });
 
@@ -61,7 +58,8 @@ module.exports = {
   },
 
   isFeatureEnabled(name) {
-    return this._features[name];
+    let value = this._features[name];
+    return  value !== undefined ? value : FEATURES[name].default;
   },
 
   config() {
@@ -69,13 +67,13 @@ module.exports = {
     let features = this._features;
 
     Object.keys(FEATURES).forEach(key => {
-      let defaultValue = FEATURES[key].default
       let value = features[key];
 
-      if (value !== defaultValue) {
+      if (value !== undefined) {
         let KEY = `_${key.toUpperCase().replace(/-/g, '_')}`;
         EmberENV[KEY] = value;
       }
+
     });
 
     return { EmberENV };

--- a/tests/optional-features-test.js
+++ b/tests/optional-features-test.js
@@ -78,14 +78,15 @@ QUnit.module('@ember/optional-features', hooks => {
     let expected = {
       EmberENV: {
         "_APPLICATION_TEMPLATE_WRAPPER": false,
-        "_TEMPLATE_ONLY_GLIMMER_COMPONENTS": true
+        "_TEMPLATE_ONLY_GLIMMER_COMPONENTS": true,
+        "_JQUERY_INTEGRATION": true
       }
     };
 
     assert.deepEqual(addon.config(), expected, 'Expecting correct config');
   });
 
-  QUnit.test('it removes features that matches their default value', assert => {
+  QUnit.test('it does not remove features that matches their default value', assert => {
     let addon = buildAddon({
       'application-template-wrapper': true,
       'template-only-glimmer-components': true,
@@ -94,7 +95,9 @@ QUnit.module('@ember/optional-features', hooks => {
 
     let expected = {
       EmberENV: {
-        "_TEMPLATE_ONLY_GLIMMER_COMPONENTS": true
+        "_APPLICATION_TEMPLATE_WRAPPER": true,
+        "_TEMPLATE_ONLY_GLIMMER_COMPONENTS": true,
+        "_JQUERY_INTEGRATION": true
       }
     };
 
@@ -167,7 +170,8 @@ QUnit.module('@ember/optional-features', hooks => {
     let expected = {
       EmberENV: {
         "_APPLICATION_TEMPLATE_WRAPPER": false,
-        "_TEMPLATE_ONLY_GLIMMER_COMPONENTS": true
+        "_TEMPLATE_ONLY_GLIMMER_COMPONENTS": true,
+        "_JQUERY_INTEGRATION": true
       }
     };
 


### PR DESCRIPTION
This is to enable the Ember runtime to distinguish between `true` by default and explicitly `true`. Which is required to correctly implement the `jQuery.originalEvent` deprecation, where this should only be triggered when jQuery is enabled by default, and not when it is explicitly enabled. Previously `EmberENV['_JQUERY_INTEGRATION']` would be `true` for both cases, with no way to distinguish. Now when the flag is not explicitly set `EmberENV['_JQUERY_INTEGRATION']` will be `undefined`, which Ember will still treat as `true` by default [here](https://github.com/emberjs/ember.js/blob/f73d8440d19cf86a10c61ddb89d45881acfcf974/packages/%40ember/-internals/views/lib/system/jquery.js#L6)

The default value will now only be used for the `isFeatureEnabled()` check, but not for populating `EmberENV` anymore.

Fixes https://github.com/emberjs/ember.js/issues/16849

*Note: I confirmed with the provided reproduction that this fixes the jQuery issue above. But I am not sure if this can have any unexpected implications for the other two optional features, as I am unaware how exactly they are implemented. So please double check if the changes here are acceptable! If not, maybe we would have to introduce another flag for a given feature, that specifies if the default value should be set or not!?* 🤔