### PR TITLE
Add default-async-observers optional feature.

### DIFF
--- a/features/default-async-observers.js
+++ b/features/default-async-observers.js
@@ -1,0 +1,9 @@
+/* eslint-disable no-console */
+'use strict';
+
+module.exports = {
+  description: 'Makes all observers asynchronous (unless manually indicated as synchronous when calling addObserver/observes).',
+  url: 'https://github.com/emberjs/rfcs/pull/494',
+  default: false,
+  since: '3.13.0'
+};


### PR DESCRIPTION
This optional feature was introduced in [emberjs/rfcs#494](https://github.com/emberjs/rfcs/blob/master/text/0494-async-observers.md).