### PR TITLE
[FEATURE] Adds isFeatureExplicitlySet API

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ included() {
 }
 ```
 
+It also exposes a method called `isFeatureExplicitlySet`, which can be used to check whether or not the user has explictly set the value of the option instead of using the default.
+
 ### At run-time (from an app or addon)
 
 WIP -- there does not yet exist a public API for accessing the state of optional features at runtime. [This](https://github.com/pzuraq/ember-compatibility-helpers/issues/27) issue is tracking it.

--- a/index.js
+++ b/index.js
@@ -62,6 +62,10 @@ module.exports = {
     return  value !== undefined ? value : FEATURES[name].default;
   },
 
+  isFeatureExplicitlySet(name) {
+    return this._features[name] !== undefined;
+  },
+
   config() {
     let EmberENV = {};
     let features = this._features;

--- a/tests/optional-features-test.js
+++ b/tests/optional-features-test.js
@@ -127,6 +127,15 @@ QUnit.module('@ember/optional-features', hooks => {
     assert.strictEqual(addon.isFeatureEnabled('template-only-glimmer-components'), false, 'Expecting default value');
   });
 
+  QUnit.test('it can query the features with `isFeatureExplicitlySet`', assert => {
+    let addon = buildAddon({
+      'application-template-wrapper': false
+    });
+
+    assert.strictEqual(addon.isFeatureExplicitlySet('application-template-wrapper'), true, 'Expecting value to exist');
+    assert.strictEqual(addon.isFeatureExplicitlySet('template-only-glimmer-components'), false, 'Expecting to not exist');
+  });
+
   QUnit.test('it allows the config to be a overridden with an ENV variable', assert => {
     process.env.EMBER_OPTIONAL_FEATURES = `{ "application-template-wrapper": false }`;
 


### PR DESCRIPTION
This API lets us check if a feature is explicitly set (e.g. given a
value in the config)