### PR TITLE
Add `--run-codemod` commandline option.

### DIFF
--- a/commands/index.js
+++ b/commands/index.js
@@ -46,7 +46,7 @@ const SHARED = {
     return configPath;
   },
 
-  _setFeature: async function (name, value) {
+  _setFeature: async function (name, value, shouldRunCodemod) {
     let feature = FEATURES[name];
 
     if (feature === undefined) {
@@ -62,7 +62,7 @@ const SHARED = {
     }
 
     if (typeof feature.callback === 'function') {
-      await feature.callback(this.project, value);
+      await feature.callback(this.project, value, shouldRunCodemod);
     }
 
     let config = {};
@@ -134,11 +134,20 @@ const ENABLE_FEATURE = Object.assign({
   name: 'feature:enable',
   description: 'Enable feature.',
   works: 'insideProject',
+  availableOptions: [
+    {
+      name: 'run-codemod',
+      type: Boolean,
+      description: 'run any associated codemods without prompting'
+      // intentionally not setting a default, when the value is undefined the
+      // command will prompt the user
+    },
+  ],
   anonymousOptions: [
     '<feature-name>'
   ],
-  run(_, args) {
-    return this._setFeature(args[0], true);
+  run(commandOptions, args) {
+    return this._setFeature(args[0], true, commandOptions.runCodemod);
   }
 }, SHARED);
 
@@ -146,11 +155,20 @@ const DISABLE_FEATURE = Object.assign({
   name: 'feature:disable',
   description: 'Disable feature.',
   works: 'insideProject',
+  availableOptions: [
+    {
+      name: 'run-codemod',
+      type: Boolean,
+      description: 'run any associated codemods without prompting'
+      // intentionally not setting a default, when the value is undefined the
+      // command will prompt the user
+    },
+  ],
   anonymousOptions: [
     '<feature-name>'
   ],
-  run(_, args) {
-    return this._setFeature(args[0], false);
+  run(commandOptions, args) {
+    return this._setFeature(args[0], false, commandOptions.runCodemod);
   }
 }, SHARED);
 

--- a/features/application-template-wrapper.js
+++ b/features/application-template-wrapper.js
@@ -13,7 +13,7 @@ module.exports = {
   url: 'https://github.com/emberjs/rfcs/pull/280',
   default: true,
   since: '3.1.0',
-  callback: async function (project, value) {
+  callback: async function (project, value, shouldRunCodemod) {
     if (value !== false) {
       return;
     }
@@ -44,34 +44,38 @@ module.exports = {
       }
     }
 
-    console.log(strip`
-      Disabling ${chalk.bold('application-template-wrapper')}...
+    if (shouldRunCodemod === undefined) {
+      console.log(strip`
+        Disabling ${chalk.bold('application-template-wrapper')}...
 
-      This will remove the \`<div class="ember-view">\` wrapper for the top-level application template (\`${templatePath}\`).
+        This will remove the \`<div class="ember-view">\` wrapper for the top-level application template (\`${templatePath}\`).
 
-      While this may be a desirable change, it might break your styling in subtle ways:
+        While this may be a desirable change, it might break your styling in subtle ways:
 
-        - Perhaps you were targeting the \`.ember-view\` class in your CSS.
+          - Perhaps you were targeting the \`.ember-view\` class in your CSS.
 
-        - Perhaps you were targeting the \`<div>\` element in your CSS (e.g. \`body > div > .some-child\`).
+          - Perhaps you were targeting the \`<div>\` element in your CSS (e.g. \`body > div > .some-child\`).
 
-        - Depending on your choice of \`rootElement\`, your app might not be wrapped inside a block-level element anymore.
+          - Depending on your choice of \`rootElement\`, your app might not be wrapped inside a block-level element anymore.
 
-      For more information, see ${chalk.underline('https://github.com/emberjs/rfcs/pull/280')}.
+        For more information, see ${chalk.underline('https://github.com/emberjs/rfcs/pull/280')}.
 
-      To be very conservative, I could add the \`<div class="ember-view">\` wrapper to your application.hbs. (You can always remove it later.)
-    `);
+        To be very conservative, I could add the \`<div class="ember-view">\` wrapper to your application.hbs. (You can always remove it later.)
+      `);
 
-    let response = await inquirer.prompt({
-      type: 'confirm',
-      name: 'shouldRewrite',
-      message: 'Would you like me to do that for you?',
-      default: false
-    });
+      let response = await inquirer.prompt({
+        type: 'confirm',
+        name: 'shouldRewrite',
+        message: 'Would you like me to do that for you?',
+        default: false
+      });
 
-    console.log();
+      console.log();
 
-    if (response.shouldRewrite) {
+      shouldRunCodemod = response.shouldRewrite;
+    }
+
+    if (shouldRunCodemod) {
       let lines = originalContent.split('\n');
       let hasFinalNewLine;
 

--- a/features/template-only-glimmer-components.js
+++ b/features/template-only-glimmer-components.js
@@ -17,7 +17,7 @@ const ComponentFile = strip`
   });
 `;
 
-/* This forces strip`` to start counting the indentaiton */
+/* This forces strip`` to start counting the indentaton */
 const INDENT_START = '';
 
 module.exports = {
@@ -25,7 +25,7 @@ module.exports = {
   url: 'https://github.com/emberjs/rfcs/pull/278',
   default: false,
   since: '3.1.0',
-  callback: async function (project, value) {
+  callback: async function (project, value, shouldRunCodemod) {
     if (value !== true) {
       return;
     }
@@ -108,45 +108,49 @@ module.exports = {
       return;
     }
 
-    console.log(strip`
-      Enabling ${chalk.bold('template-only-glimmer-components')}...
-
-      This will change the semantics for template-only components (components without a \`.js\` file).
-
-      Some notable differences include...
-
-        - They will not have a component instance, so statements like \`{{this}}\`, \`{{this.foo}}\` and \`{{foo}}\` will be \`null\` or \`undefined\`.
-
-        - They will not have a wrapper element: what you have in the template will be what is rendered on the screen.
-
-        - Passing classes in the invocation (i.e. \`{{my-component class="..."}}\`) will not work, since there is no wrapper element to apply the classes to.
-
-      For more information, see ${chalk.underline('https://github.com/emberjs/rfcs/pull/278')}.
-
-      While these changes may be desirable for ${chalk.italic('new components')}, they may unexpectedly break the styling or runtime behavior of your ${chalk.italic('existing components')}.
-
-      To be conservative, it is recommended that you add a \`.js\` file for existing template-only components. (You can always delete them later if you aren't relying on the differences.)
-
-      The following components are affected:`);
-
-    for (let i=0; i<templates.length; i++) {
+    if (shouldRunCodemod === undefined) {
       console.log(strip`
+        Enabling ${chalk.bold('template-only-glimmer-components')}...
+
+        This will change the semantics for template-only components (components without a \`.js\` file).
+
+        Some notable differences include...
+
+          - They will not have a component instance, so statements like \`{{this}}\`, \`{{this.foo}}\` and \`{{foo}}\` will be \`null\` or \`undefined\`.
+
+          - They will not have a wrapper element: what you have in the template will be what is rendered on the screen.
+
+          - Passing classes in the invocation (i.e. \`{{my-component class="..."}}\`) will not work, since there is no wrapper element to apply the classes to.
+
+        For more information, see ${chalk.underline('https://github.com/emberjs/rfcs/pull/278')}.
+
+        While these changes may be desirable for ${chalk.italic('new components')}, they may unexpectedly break the styling or runtime behavior of your ${chalk.italic('existing components')}.
+
+        To be conservative, it is recommended that you add a \`.js\` file for existing template-only components. (You can always delete them later if you aren't relying on the differences.)
+
+        The following components are affected:`);
+
+      for (let i=0; i<templates.length; i++) {
+        console.log(strip`
         ${INDENT_START}
           - ${chalk.underline(templates[i])}
             ${chalk.gray(`(Recommendation: add ${chalk.cyan.underline(components[i])})`)}
-      `);
+        `);
+      }
+
+      let response = await inquirer.prompt({
+        type: 'confirm',
+        name: 'shouldGenerate',
+        message: 'Would you like me to generate these component files for you?',
+        default: true
+      });
+
+      shouldRunCodemod = response.shouldGenerate;
+
+      console.log();
     }
 
-    let response = await inquirer.prompt({
-      type: 'confirm',
-      name: 'shouldGenerate',
-      message: 'Would you like me to generate these component files for you?',
-      default: true
-    });
-
-    console.log();
-
-    if (response.shouldGenerate) {
+    if (shouldRunCodemod) {
       for (let i=0; i<components.length; i++) {
         let componentPath = components[i];
         console.log(`  ${chalk.green('create')} ${componentPath}`);


### PR DESCRIPTION
This allows tools like `@ember/octanify` to pass `--run-codemods` in it's own CI system without having to worry about properly mocking `STDIN`.

This is not _really_ expected to be used as an actual flag users would specify, but it is fine if they do (which is why the `--run-codemod` flag has a description so that it will show up in `--help` output).