### PR TITLE
Lazy load `inquirer` module

### DIFF
--- a/features/application-template-wrapper.js
+++ b/features/application-template-wrapper.js
@@ -3,7 +3,6 @@
 
 const chalk = require('chalk');
 const fs = require('fs');
-const inquirer = require('inquirer');
 const p = require('util').promisify;
 const path = require('path');
 const strip = require('../utils').strip;
@@ -74,7 +73,7 @@ module.exports = {
         To be very conservative, I could add the \`<div class="ember-view">\` wrapper to your application.hbs. (You can always remove it later.)
       `);
 
-      let response = await inquirer.prompt({
+      let response = await require('inquirer').prompt({
         type: 'confirm',
         name: 'shouldRewrite',
         message: 'Would you like me to do that for you?',

--- a/features/template-only-glimmer-components.js
+++ b/features/template-only-glimmer-components.js
@@ -3,7 +3,6 @@
 
 const chalk = require('chalk');
 const fs = require('fs');
-const inquirer = require('inquirer');
 const glob = require('glob');
 const mkdirp = require('mkdirp');
 const p = require('util').promisify;
@@ -181,7 +180,7 @@ module.exports = {
         `);
       }
 
-      let response = await inquirer.prompt({
+      let response = await require('inquirer').prompt({
         type: 'confirm',
         name: 'shouldGenerate',
         message: 'Would you like me to generate these component files for you?',


### PR DESCRIPTION
Because eagerly loading heavy modules slows down every ember command.
This change makes a difference of about 50ms.