### PR TITLE
Set local dev version of node to v18

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,8 @@
       "release": true,
       "tokenRef": "GITHUB_AUTH"
     }
+  },
+  "volta": {
+    "node": "18.19.0"
   }
 }


### PR DESCRIPTION
We're still testing against node 10+, but I kind of want to see if it's possible to setup release-plan without a breaking change