### PR TITLE
[e18e] replace mkdirp with native mkdirSync with recursive: true

### DIFF
--- a/commands/index.js
+++ b/commands/index.js
@@ -4,11 +4,11 @@
 const VersionChecker = require('ember-cli-version-checker');
 
 const fs = require('fs');
-const mkdirp = require('mkdirp');
 const path = require('path');
 const { styleText } = require('node:util');
 const strip = require('../utils').strip;
 const getConfigPath = require('../utils').getConfigPath;
+const { mkdirSync } = require('node:fs');
 
 const FEATURES = require('../features');
 
@@ -48,7 +48,9 @@ const SHARED = {
       }
     }
 
-    mkdirp.sync(path.join(this.project.root, path.dirname(configPath)));
+    mkdirSync(path.join(this.project.root, path.dirname(configPath)), {
+      recursive: true,
+    });
 
     fs.writeFileSync(configPath, '{}', { encoding: 'UTF-8' });
 

--- a/features/template-only-glimmer-components.js
+++ b/features/template-only-glimmer-components.js
@@ -4,7 +4,7 @@
 const { styleText } = require('node:util');
 const fs = require('fs');
 const globSync = require('glob').globSync;
-const mkdirp = require('mkdirp');
+const { mkdirSync } = require('node:fs');
 const p = require('util').promisify;
 const path = require('path');
 const strip = require('../utils').strip;
@@ -208,7 +208,7 @@ module.exports = {
         let componentPath = components[i];
         console.log(`  ${styleText('green', 'create')} ${componentPath}`);
         let absolutePath = path.join(project.root, componentPath);
-        await mkdirp(path.dirname(absolutePath));
+        await mkdirSync(path.dirname(absolutePath), { recursive: true });
         await p(fs.writeFile)(absolutePath, ComponentFile, {
           encoding: 'UTF-8',
         });

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "ember-cli-version-checker": "^5.1.2",
     "glob": "^13.0.1",
     "inquirer": "^13.2.2",
-    "mkdirp": "^1.0.4",
     "silent-error": "^1.1.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       inquirer:
         specifier: ^13.2.2
         version: 13.2.2(@types/node@25.2.2)
-      mkdirp:
-        specifier: ^1.0.4
-        version: 1.0.4
       silent-error:
         specifier: ^1.1.1
         version: 1.1.1

--- a/tests/commands-test.js
+++ b/tests/commands-test.js
@@ -5,7 +5,7 @@ const CWD = process.cwd();
 const fs = require('fs');
 const createTempDir = require('broccoli-test-helper').createTempDir;
 const execa = require('execa');
-const mkdirp = require('mkdirp');
+const { mkdirSync } = require('node:fs');
 const p = require('path').join;
 const strip = require('../utils').strip;
 const { stripVTControlCharacters: stripAnsi } = require('node:util');
@@ -45,11 +45,11 @@ QUnit.module('commands', (hooks) => {
 
     process.chdir(project.path());
 
-    mkdirp.sync(p(CWD, 'node_modules', '@ember'));
+    mkdirSync(p(CWD, 'node_modules', '@ember'), { recursive: true });
     fs.symlinkSync(p(CWD, 'node_modules'), p(project.path(), 'node_modules'));
     fs.symlinkSync(CWD, p(CWD, 'node_modules', '@ember', 'optional-features'));
 
-    mkdirp.sync(p(CWD, 'node_modules', 'ember-source'));
+    mkdirSync(p(CWD, 'node_modules', 'ember-source'), { recursive: true });
     fs.writeFileSync(
       p(CWD, 'node_modules', 'ember-source', 'package.json'),
       strip`


### PR DESCRIPTION
This is recommended by the e18e project here: https://github.com/es-tooling/module-replacements/blob/main/docs/modules/mkdirp.md#nodejs-since-v10120