### PR TITLE
[e18e] replace glob with tinyglobby

### DIFF
--- a/features.js
+++ b/features.js
@@ -1,13 +1,12 @@
 'use strict';
 
-const glob = require('glob');
+const { globSync } = require('tinyglobby');
 const path = require('path');
 
 const FEATURES_PATH = path.resolve(__dirname, './features');
 const FEATURES = {};
 
-glob
-  .sync('*.js', { cwd: FEATURES_PATH })
+globSync('*.js', { cwd: FEATURES_PATH })
   .sort()
   .forEach((filename) => {
     let key = filename.slice(0, -3);

--- a/features/template-only-glimmer-components.js
+++ b/features/template-only-glimmer-components.js
@@ -3,7 +3,7 @@
 
 const { styleText } = require('node:util');
 const fs = require('fs');
-const globSync = require('glob').globSync;
+const { globSync } = require('tinyglobby');
 const { mkdirSync } = require('node:fs');
 const p = require('util').promisify;
 const path = require('path');

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   },
   "dependencies": {
     "ember-cli-version-checker": "^5.1.2",
-    "glob": "^13.0.1",
     "inquirer": "^13.2.2",
-    "silent-error": "^1.1.1"
+    "silent-error": "^1.1.1",
+    "tinyglobby": "^0.2.15"
   },
   "devDependencies": {
     "broccoli-test-helper": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,15 +11,15 @@ importers:
       ember-cli-version-checker:
         specifier: ^5.1.2
         version: 5.1.2
-      glob:
-        specifier: ^13.0.1
-        version: 13.0.1
       inquirer:
         specifier: ^13.2.2
         version: 13.2.2(@types/node@25.2.2)
       silent-error:
         specifier: ^1.1.1
         version: 1.1.1
+      tinyglobby:
+        specifier: ^0.2.15
+        version: 0.2.15
     devDependencies:
       broccoli-test-helper:
         specifier: ^2.0.0
@@ -7066,7 +7066,7 @@ snapshots:
 
   humanize-ms@1.2.1:
     dependencies:
-      ms: 2.1.3
+      ms: 2.0.0
 
   iconv-lite@0.4.24:
     dependencies:


### PR DESCRIPTION
This is recommended by the e18e project here: https://github.com/es-tooling/module-replacements/blob/main/docs/modules/glob.md#tinyglobby

Note: I didn't move to the native solution because we need to support Node 20 and that is only available from Node 22